### PR TITLE
Implementierung von File-Locks

### DIFF
--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -2,13 +2,25 @@
 # DO NOT MODIFY THIS LINE 5M7AnOtp5R8XZlcgkQrSntFgW6gXgm7M
 # Test
 #Test2
+echo Start Backup-Script...
 if [ -z $backup_bwlimit ]
 then
   backup_bwlimit=4M
 fi
-datum=$(date +%F)
+echo Verwende Bandbreitenlimit: $backup_bwlimit
+echo Binde SFTP-Verzeichnis ein.
 sshfs -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect $backup_nutzername@$backup_adresse:/ /mnt/sftp/
-rclone sync --create-empty-src-dirs -v /mnt/sftp/backup/ /mnt/lokal/ --bwlimit $backup_bwlimit --log-file /config/logs/duplicati-sftp-$datum.log --stats 30s
+while [ -f "/mnt/sftp/backup/file.lock" ]
+do
+  echo Lock-Datei erkannt. Prüfe erneut in 60 Sekunden.
+  sleep 60
+done
+datum=$(date +%F)
+echo Starte Backup. Logs sind zu finden unter logs/duplicati-sftp-$datum.log
+rclone sync --create-empty-src-dirs -v /mnt/sftp/backup/ /mnt/lokal/ --bwlimit $backup_bwlimit --log-file /config/logs/duplicati-sftp-$datum.log --stats 120s
+echo Backup beendet. Kopiere Logdatei auf Server...
 cp /config/logs/duplicati-sftp-$datum.log /mnt/sftp/statistik/duplicati-sftp-$datum.log
 umount -lf /mnt/sftp/
-echo Backup beendet.
+echo Backup-Script beendet.
+
+

--- a/scripts/cron_update.sh
+++ b/scripts/cron_update.sh
@@ -2,23 +2,21 @@
 # DO NOT MODIFY THIS LINE 5M7AnOtp5R8XZlcgkQrSntFgW6gXgm7M
 
 # Editable Variables:
-backup_cron_freq="15 5 * * *"
+backup_cron_freq="10 3 * * *"
 setup_cron_freq="5 0 * * *"
 
 if [ -z "$backup_manuelle_frequenz" ]
 then
-  echo Keine manuelle Cron-Frequenz gesetzt, verwende Standardfrequenz: $backup_cron_freq
+  echo "Keine manuelle Cron-Frequenz gesetzt, verwende Standardfrequenz: $backup_cron_freq"
 else
   backup_cron_freq=$backup_manuelle_Frequenz
-  echo Manuelle Cron-Frequenz gesetzt, diese wird verwendet und lautet $backup_cron_freq
+  echo "Manuelle Cron-Frequenz gesetzt, diese wird verwendet und lautet $backup_cron_freq"
 fi
 
 cronedit () {
   crontab -l > cron.temp
   sed -i '/\/home\/scripts\/backup_script.sh/d' cron.temp
-  echo "$backup_cron_freq /home/scripts/backup_script.sh">>cron.temp
-  sed -i '/\/home\/scripts\/setup.sh/d' cron.temp
-  echo "$setup_cron_freq /home/scripts/setup.sh">>cron.temp
+  echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh">>cron.temp
   crontab cron.temp
   rm -f cron.temp
   echo Crontab aktualisiert. Starte crond.


### PR DESCRIPTION
- Lock des Cronjobs (keine mehrfache Ausführung)
- Backup Script prüft auf file.lock im backup/-Verzeichnis vor Beginn des Backups
- Mehr Informationen im Script für Log
- Anpassung Standard-Backup Zeit auf 03:15 Uhr