### PR TITLE
Docker Image-Größe schrumpfen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ RUN apk add --no-cache rclone openssh-keygen sshfs tzdata
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN apk del --no-cache tzdata
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp && mkdir /mnt/lokal
-COPY ./scripts/* /home/scripts
+COPY ./scripts/* /home/scripts/
 CMD /home/scripts/startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2
-RUN apk add rclone openssh-keygen sshfs tzdata 
+RUN apk add --no-cache rclone openssh-keygen sshfs tzdata 
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
-RUN apk del tzdata
+RUN apk del --no-cache tzdata
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp && mkdir /mnt/lokal
 COPY ./scripts/* /home/scripts
 CMD /home/scripts/startup.sh


### PR DESCRIPTION
- Nutzen der apk --no-cache flag um die Image-Größe des Dockers zu verkleinern