### PR TITLE
Log Output, Löschverhalten, Readme

### DIFF
--- a/.github/workflows/docker-publish-dev
+++ b/.github/workflows/docker-publish-dev
@@ -1,0 +1,83 @@
+name: Docker-dev-Build
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "dev" ]
+    # Publish tags as releases.
+    tags: [ 'dev' ]
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: butti/sftp-backup
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: butti
+          password: ${{ secrets.DOCKER_PW }}
+          
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract ghcr.io metadata
+        id: meta-ghcr
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/XLixl4snSU/sftp-backup
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}, ${{ steps.meta-ghcr.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Die Ausführung des Backups erfolgt einmal täglich mittels cron. Ein Lockfile s
 - Die Backups befinden sich in Ordnern des Formats `YYYY-MM-DD`
 - Ist noch kein Ordner im Format vorhanden, erfolgt ein erstes Voll-Backup. Alle nachfolgenden Backups verwenden stets Hardlinks mit Basis des jeweils letzten Backups zur Sicherung
 - Es kann jederzeit jede Backup-Version unabhängig von allen anderen Backups gelöscht werden, dies hat keinen Effekt auf andere Backup-Versionen.
-- **Achtung:** im Rahmen des Backup-Scripts werden alle fremden Ordner im gewählten Backup-Verzeichnis gelöscht. Das trifft **nicht** auf einzelne Dateien zu.
+- **Achtung:** im Rahmen des Backup-Scripts werden alle fremden Ordner im gewählten Backup-Verzeichnis im Format `YYYY-MM-DD` bzw. präziser der regex `\d\d\d\d-\d\d-\d\d` gelöscht. Einzelne Dateien oder Ordner die nicht dem Regex-Format entsprechen werden **nicht** gelöscht oder verändert.
 - Das Script prüft nach Ausführung eines Backups ob mehr als die in `backup_retention_number` definierten Backups vorhanden sind. Wenn ja, wird das jeweils **älteste** Backup gelöscht.
 - Existiert bereits vor der Nutzung ein volles Backup, kann dieses einfach in einen Ordner mit dem aktuellen Datum im Format `YYYY-MM-DD` verschoben werden. Es dient dann als Basis für zukünftige Backups.
 - Backups, die am Ende des Rsync-Vorgangs nicht **exakt** in Größe dem Ursprung entsprechen werden zur Vermeidung korrupter Backups gelöscht. Ein Backup muss dann erneut erfolgen, bspw. am nächsten Tag oder manuell

--- a/scripts/backup_now.sh
+++ b/scripts/backup_now.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-$(date +%F).log; cp -rf /config/logs/backup_script-$(date +%F).log /mnt/sftp/statistik/backup_script-$(date +%F).log; umount -lf /mnt/sftp/
+flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-$(date +%F).log 2>&1; cp -rf /config/logs/backup_script-$(date +%F).log /mnt/sftp/statistik/backup_script-$(date +%F).log; umount -lf /mnt/sftp/

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -131,7 +131,7 @@ to_delete=$(find $dest_folder -type d -mindepth 1 $do_not_delete)
 if [ -n "$to_delete" ]
 then
   echo $(d)": Lösche alle anderen Ordner (behalte letzte $backup_retention_number Sicherungen): $to_delete"
-  find $dest_folder -type d -mindepth 1 $do_not_delete -exec rm -r {} +
+  find $dest_folder -regex ".*/\d\d\d\d-\d\d-\d\d" -type d -mindepth 1 $do_not_delete -exec rm -r {} +
 else
   echo $(d)": Es müssen keine alten Backups gelöscht werden ($found von $backup_retention_number (Retention) Sicherungen vorhanden)."
 fi

--- a/scripts/cron_update.sh
+++ b/scripts/cron_update.sh
@@ -14,7 +14,7 @@ fi
 cronedit () {
   crontab -l > cron.temp
   sed -i '/\/home\/scripts\/backup_script.sh/d' cron.temp
-  echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-\$(date +%F).log; cp -rf /config/logs/backup_script-\$(date +%F).log /mnt/sftp/statistik/backup_script-\$(date +%F).log; umount -lf /mnt/sftp/">>cron.temp
+  echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-\$(date +%F).log 2>&1; cp -rf /config/logs/backup_script-\$(date +%F).log /mnt/sftp/statistik/backup_script-\$(date +%F).log; umount -lf /mnt/sftp/">>cron.temp
   crontab cron.temp
   rm -f cron.temp
   echo "Crontab aktualisiert. Starte crond."


### PR DESCRIPTION
-  Backup-Script-Log gibt nun auch stderr wieder
- Nur Ordner die von der regex `\d\d\d\d-\d\d-\d\d` werden noch automatisch durch die Retention-Routine gelöscht, keine anderen Ordner mehr
- Readme entsprechend angepasst