### PR TITLE
find, regex, rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.16.2
-RUN apk add --no-cache rsync openssh-keygen sshfs tzdata coreutils bash
+RUN apk add --no-cache rsync openssh-keygen sshfs tzdata coreutils bash findutils
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp && mkdir /mnt/lokal
 COPY ./scripts/* /home/scripts/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 ![](https://img.shields.io/github/workflow/status/XLixl4snSU/sftp-backup/Docker?style=flat-square)
 ![](https://img.shields.io/github/release-date/XLixl4snSU/sftp-backup?style=flat-square)
 ![](https://img.shields.io/docker/v/butti/sftp-backup/latest?style=flat-square)
@@ -48,6 +49,11 @@ Release laden, entpacken und im Rootverzeichnis Kommando ausführen (erfordert d
 Der Container muss **privilegiert** (privileged) gestartet werden!
 
 Die notwendigen [Variablen und Volumen](#Variablen-und-Volumen) müssen vor Start eingerichtet werden.
+
+Beispiel:
+
+    docker run --privileged --name sftp-backup -e "backup_port=2025" -e "backup_nutzername=ichbineinnutzer" -e "backup_adresse=sftp.domain.com" -v "/home/sftp-data/config:/config" -v "/home/sftp-data/lokal:/mnt/lokal/" -v "/home/sftp-data/sftp:/mnt/sftp" -d butti/sftp-backup:latest
+    
 
 Nach dem ersten Start des Containers werden standardmäßig **SSH-Keys** erzeugt. Diese befinden sich anschließend im eingebundenen Config-Ordner.
 Es können auch **eigene RSA-SSH-Keys** verwendet werden, welche sich vor Start des Containers im Config-Ordner befinden, diese müssen "private_key" sowie "public_key" heißen.
@@ -100,3 +106,4 @@ Die Ausführung des Backups erfolgt einmal täglich mittels cron. Ein Lockfile s
 - Es kann durch die Ausführung von `./backup-now` im Root-Verzeichnis jederzeit ein sofortiges Backup angestoßen werden.
 
 Dieser Container **speichert Logdateien** im Ordner /config/logs: Diese sind aktuell bei Bedarf manuell zu löschen.
+

--- a/scripts/backup_now.sh
+++ b/scripts/backup_now.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-$(date +%F).log 2>&1; cp -rf /config/logs/backup_script-$(date +%F).log /mnt/sftp/statistik/backup_script-$(date +%F).log; umount -lf /mnt/sftp/
+flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-$(date +%F).log 2>&1; rsync -a /config/logs/ /mnt/sftp/statistik/; umount -lf /mnt/sftp/

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -39,7 +39,7 @@ then
   exit 0
 fi
 
-cp -rf $logs_folder* $stat_folder
+rsync -a $logs_folder $stat_folder
 
 while [ -f "$sftp_backup_folder"file.lock"" ]
 do
@@ -131,7 +131,7 @@ to_delete=$(find $dest_folder -type d -mindepth 1 $do_not_delete)
 if [ -n "$to_delete" ]
 then
   echo $(d)": Lösche alle anderen Ordner (behalte letzte $backup_retention_number Sicherungen): $to_delete"
-  find $dest_folder -regex "^.*/\d\{4\}-\d\{2\}-\d\{2\}$" -type d -mindepth 1 $do_not_delete -exec rm -r {} +
+  find $dest_folder -mindepth 1 -type d -regextype "egrep" -regex "^.*/[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}$" $do_not_delete -exec rm -r {} +
 else
   echo $(d)": Es müssen keine alten Backups gelöscht werden ($found von $backup_retention_number (Retention) Sicherungen vorhanden)."
 fi

--- a/scripts/cron_update.sh
+++ b/scripts/cron_update.sh
@@ -14,7 +14,7 @@ fi
 cronedit () {
   crontab -l > cron.temp
   sed -i '/\/home\/scripts\/backup_script.sh/d' cron.temp
-  echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-\$(date +%F).log 2>&1; cp -rf /config/logs/backup_script-\$(date +%F).log /mnt/sftp/statistik/backup_script-\$(date +%F).log; umount -lf /mnt/sftp/">>cron.temp
+  echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh >> /config/logs/backup_script-\$(date +%F).log 2>&1; rsync -a /config/logs/ /mnt/sftp/statistik/; umount -lf /mnt/sftp/">>cron.temp
   crontab cron.temp
   rm -f cron.temp
   echo "Crontab aktualisiert. Starte crond."


### PR DESCRIPTION
- Update busybox-find auf gnu-find
- - für mit non-busybox-Systemen kompatibles Regex-Matching
- rsync statt cp für logs auf SFTP
- - Reduziert notwendigen Datenverkehr

