### PR TITLE
Change project language to english

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ RUN apk add --no-cache rsync openssh-keygen sshfs tzdata coreutils bash findutil
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp && mkdir /mnt/lokal
 COPY ./scripts/* /home/scripts/
-RUN chmod +x /home/scripts/*; ln /home/scripts/backup_now.sh /backup-now
+RUN chmod +x /home/scripts/*; ln /home/scripts/backup_now.sh /usr/bin/backup-now
 CMD /home/scripts/startup.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 
+
 ![](https://img.shields.io/github/workflow/status/XLixl4snSU/sftp-backup/Docker?style=flat-square)
 ![](https://img.shields.io/github/release-date/XLixl4snSU/sftp-backup?style=flat-square)
 ![](https://img.shields.io/docker/v/butti/sftp-backup/latest?style=flat-square)
@@ -12,98 +13,107 @@
  
 ## Überblick
 - [Features](#Features)
-- [Installation und Setup](#Installation-und-Setup)
-	- [Bezugsquellen](#Bezugsquellen-fertiger-Images)
-	- [Selbst bauen](#Selbst-bauen)
-	- [Erster Start](#Erster-Start)
-- [Variablen und Volumen](#Variablen-und-Volumen)
-- [Laufender Betrieb](#Laufender-Betrieb)
+- [Requirements, Installation and Setup](#Requirements,-Installation-and-Setup)
+	- [Where to get the Image](#Where-to-get-the-Image)
+	- [Build locally](#Build-locally)
+	- [First Start](#First-Start)
+- [Environment variables and volumes](#Environment-variables-and-volumes) 
+- [ Running the container](#Running-the-container)
 
 ## Features
-Es handelt sich um eine individuelle Lösung um Dateien mit einer Server-Client-Architektur zu sichern auf Dockerbasis. Hierbei hat der Client nur lesenden Zugriff auf die Daten des Servers und der Server hat keinen Zugriff auf Daten des Clients.
-Das Backup wird über eine SFTP-Verbindung mittels rsync zu einer festgelegten Zeit durchgeführt
+This project is the base for a docker container that provides the possibility to create local backups from a remote SFTP-Host with rsync. It's customized for my personal use, but it can be used by anybody.
 
 **Core-Features:**
 
- - Alpine Linux als Basis
- - Backups von Dateien eines SFTP-Servers zu einem definierbaren Zeitpunkt einmal täglich
- - Inkrementelle Backups mit frei wählbarer Retention-Anzahl
-	 - Einzelne Backups können dank Hardlinks ohne Einfluss auf andere Backups jederzeit gelöscht werden
- - Authentication mittels SSH-Keys
- - Einfach zugänglicher Log
-## Installation und Setup
-Es handelt sich um einen Docker-Container. Das Image kann von Registries bezogen, aber auch lokal selbst gebaut werden.
-### Bezugsquellen fertiger Images
-|Bezugsquellen| Name |
+ - Docker base image: Alpine Linux
+ - Very lightweight (<10mb compressed docker image)
+ - Backups of files on a remote SFTP-Server on time a day
+ - Rudimentary incremental Backups with a custom retention period in days
+ - Authentication by SSH-Keys
+ - Easily accessible Logs with extensive information of the process
+## Requirements, Installation and Setup
+This project is the base of of Docker container. You can pull the image from DockerHub and GitHub Container Repository, but also build it locally.
+### Requirements:
+ - Docker installed on your host machine. See https://docs.docker.com/engine/install/ for instructions.
+ - SFTP-Server that supports authentication via RSA-SSH-Keys (basically all should do)
+	 - folder `backup/` in the users root directory
+		 - this is where you mount the data that you want to back up
+		 - you should configure this folder to be **read-only** by the SFTP-user
+	 - optionally (but highly recommended) folder `logs/` in the users root directory
+		 - this is where logs are saved to from the remote container
+		 - this needs to be configured **read-write**
+
+
+
+### Where to get the Image
+|Registry| Name |
 |--|--|
 |[Github Container Registry](https://github.com/XLixl4snSU/sftp-backup/pkgs/container/sftp-backup)|`ghcr.io/xlixl4snsu/sftp-backup`
 | [Dockerhub](https://hub.docker.com/r/butti/sftp-backup) | `butti/sftp-backup` |
 
-Der Container wird bei Release einer neuen Version auf Github **automatisch** zu den Repositories gepusht und kann sofort geupdatet werden.
-### Selbst bauen
-Release laden, entpacken und im Rootverzeichnis Kommando ausführen (erfordert die Installation von [Docker](https://docs.docker.com/engine/install/)):
+The container is build via GitHub Actions and automatically pushed to the repositories (updating the :latest tag and creating a semver tag like :1.0.1).
+If you use the latest version (which is the default when pulling with no :tag) you can install updates just by pulling the image and recreating the container.
+### Build locally
+This is only for advanced users.
+Download a release, extract it and run the following command in the root folder:
 
     docker build .
 
-### Erster Start
-Der Container muss **privilegiert** (privileged) gestartet werden!
+### First Start
+You have to run the container with the **privileged** flag, otherwise the fuse mount won't work (and therefore also the container).
 
-Die notwendigen [Variablen und Volumen](#Variablen-und-Volumen) müssen vor Start eingerichtet werden.
+See [Environment variables and volumes](#Environment-variables-and-volumes) for the flags you need to run the container.
 
-Beispiel:
+Example:
 
-    docker run --privileged --name sftp-backup -e "backup_port=2025" -e "backup_nutzername=ichbineinnutzer" -e "backup_adresse=sftp.domain.com" -v "/home/sftp-data/config:/config" -v "/home/sftp-data/lokal:/mnt/lokal/" -d butti/sftp-backup:latest
+    docker run --privileged --name sftp-backup -e "backup_port=2025" -e "backup_user=myusername" -e "backup_address=sftp.domain.com" -v "/path/to/local/folder/config:/config" -v "/path/to/local/folder/local:/mnt/local/" -d butti/sftp-backup:latest
     
 
-Nach dem ersten Start des Containers werden standardmäßig **SSH-Keys** erzeugt. Diese befinden sich anschließend im eingebundenen Config-Ordner.
-Es können auch **eigene RSA-SSH-Keys** verwendet werden, welche sich vor Start des Containers im Config-Ordner befinden, diese müssen "private_key" sowie "public_key" heißen.
+When you start the container for the first time, it will create **SSH-Keys** (if they don't already exist). These will be located in your mounted config-folder.
+It is possible to use your own **RSA-SSH-Keys**. They have to be named `id_rsa` (private key) and `id_rsa.pub` (public key). Make sure they are in the correct format, because they won't be checked atm. It is always a good practice to let the container generate them for you. 
+You now have to use this public key and add it as a authentication method on your server. See the documentation of the SFTP-Server you are using on how to do it. It is **not possible** to use a password to authenticate for security reasons.
 
-Der **Public-Key** muss dem SFTP-Server-Administrator übermittelt werden.
-Dieser Container unterstützt **keine** Authentifizierung mittels Passwort. Es müssen immer SSH-Keys verwendet werden.
+The container will **always stop** after start if the startup script can't successfully establish a connection to the SFTP-Server.
+If you haven't provided keys beforehand it is therefore expected for the container to stop after the first start. Just start it again once your SFTP-Server is configured to use the public key.
 
-Der Container **stoppt immer** nach dem Start, wenn die Einbindung des SFTP-Ordners nicht erfolgreich war.
-Ein Stop nach dem ersten Start ohne vorher eingefügte SSH-Keys ist daher normal (da keine erfolgreiche Authentifizierung stattfinden kann).
-
-Innerhalb des SFTP-Root-Verzeichnisses erwartet dieser Container einen Ordner "backup/", in denen die zu sichernden Dateien liegen und einen Ordner "statistik/" in den nach Abschluss der Synchronisation der Log von Rsync übertragen wird.
+Make sure that the folder `backup/` exists in the root folder of your SFTP-User (see [requirements](#requirements)).
 
 
-## Variablen und Volumen
+## Environment variables and volumes
 
-|Notwendige Volumen|Host-Pfad|Container-Pfad|
+|Mandatory volumes|Host path|Container path|
 |--|--|--| 
-|Speicherort für Backup-Daten|Frei wählbar|/mnt/lokal|
-|Config-Ordner (SSH-Keys & Logs)|Frei wählbar|/config|
+|backup folder|as you wish|/mnt/local|
+|config folder (SSH-Keys & Logs)|as you wish|/config|
 ---
-|Variable|Format|Notwendig?|Info|Standardwert
+|Variable|Format|Mandatory?|Info|Default value
 |--|--|--|--|--|
-|backup_adresse|domain.com \| IP|Ja| SFTP-Server-URL|-
-|backup_port|Zahl (0-65535)|Ja|Port des SFTP-Servers|-
-|backup_nutzername|String|Ja|SFTP-Nutzername|-
-|backup_bwlimit|Zahl mit Einheit|Optional|Bandbreitenlimit während des Backups. Mit Angabe der Einheit, z.B. MB = Megabyte|4M
-|backup_manuelle_frequenz|Nach Crontab |Optional|Siehe https://crontab.guru|10 3 * * *
-|backup_retention_number|Ganzzahl| Optional|Behält die letzten X täglichen Sicherungen|7
-|TZ|Kontinent/Stadt|Optional|Zeitzone (siehe [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))|Europe/Berlin
+|backup_address|domain.com \| IP|Ja| URL or IP of the SFTP server|-
+|backup_port|Zahl (0-65535)|Ja|Port SFTP server|-
+|backup_user|String|Ja|SFTP username|-
+|backup_bwlimit|number and unit|Optional|Bandwith limit during the backup. Always add a unit, e.g. M = Megabyte|4M
+|backup_manual_frequency|See Crontab |Optional|See https://crontab.guru|10 3 * * *
+|backup_retention_number|int| Optional|Keeps last X (daily) Backups|7
+|TZ|Continent/City|Optional|Timezone (see [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))|Europe/Berlin
 
-Sind notwendige Umgebungsvariablen nicht oder falsch deklariert **stoppt** der Container nach einem Selbsttest.
+Mandatory variables have to be declared, otherwise the container will stop after a healtcheck.
 
 
-## Laufender Betrieb
-Dieser Container **stoppt nicht**, wenn ein Backup fehlschlägt oder der SFTP-Server nicht erreichbar ist. 
+## Running the container
+The container **won't stop** if a backup fails or the SFTP server isn't reachable anymore. You therefore have to check logs regularly.
+If theres a file `file.lock` in the `backup/` folder on the SFTP server the script will wait until the files is deleted (check every 60 seconds).
+This is useful if you for example backup a backup and you don't want to transfer incomplete or inconsistent data. 
+Just create a file called `file.lock`for the duration the contents of the directory are changed and remove it afterwards (easy to automate if you for example use a script).
 
-Befindet sich zum avisierten Zeitpunkt des Backups eine Datei `file.lock` im Verzeichnis `backup/`wird die ausführung des Backups so lange um jeweils 60 Sekunden verschoben, bis die Datei nicht mehr existiert.
+#### Backup functionality:
 
-Die Ausführung des Backups erfolgt einmal täglich mittels cron. Ein Lockfile sorgt dafür, dass der Cronjob nicht mehrmals gleichzeitig ausgeführt wird.
-
-#### Backup-Funktionalität:
-- Unabhängig vom Cronjob wird immer nur ein gleichzeitiges Backup des selben Tages angelegt, bei erneutem ausführen wird das bisherige Backup überschrieben
-- Die Backups befinden sich in Ordnern des Formats `YYYY-MM-DD`
-- Ist noch kein Ordner im Format vorhanden, erfolgt ein erstes Voll-Backup. Alle nachfolgenden Backups verwenden stets Hardlinks mit Basis des jeweils letzten Backups zur Sicherung
-- Es kann jederzeit jede Backup-Version unabhängig von allen anderen Backups gelöscht werden, dies hat keinen Effekt auf andere Backup-Versionen.
-- **Achtung:** im Rahmen des Backup-Scripts werden alle fremden Ordner im gewählten Backup-Verzeichnis im Format `YYYY-MM-DD` bzw. präziser der regex `\d{4}-\d{2}-\d{2}$` gelöscht. Einzelne Dateien oder Ordner die nicht dem Regex-Format entsprechen werden **nicht** gelöscht oder verändert.
-- Das Script prüft nach Ausführung eines Backups ob mehr als die in `backup_retention_number` definierten Backups vorhanden sind. Wenn ja, wird das jeweils **älteste** Backup gelöscht.
-- Existiert bereits vor der Nutzung ein volles Backup, kann dieses einfach in einen Ordner mit dem aktuellen Datum im Format `YYYY-MM-DD` verschoben werden. Es dient dann als Basis für zukünftige Backups.
-- Meldet rsync einen Fehler beim Backup, wird die angelegte Kopie zur Wahrung der Integrität und Korrektheit gelöscht. Es muss dann ein erneutes Backup erfolgen (manuell oder automatisch). 
-- Es kann durch die Ausführung von `./backup-now` im Root-Verzeichnis jederzeit ein sofortiges Backup angestoßen werden.
-
-Dieser Container **speichert Logdateien** im Ordner /config/logs: Diese sind aktuell bei Bedarf manuell zu löschen.
-
+- The backups are structured in folders named  `YYYY-MM-DD`
+- If there is no folder following this convention at all, the script will create a new full backup
+- Every following backup will use hard links to the latest backup 
+- Because this container uses hard links you can delete any `YYYY-MM-DD`  folder you want, this won't affect the remaining backups
+- After backup execution the script will delete any backups that exceed the defined `backup_retention_number` (from oldest to newest)
+- If you already have a local backup you can move it in the mounted folder and rename it in the sheme used by the container: `YYYY-MM-DD` to the current date, so for example `2022-10-24`. This backup will now be used as a base for the incremental backups.
+- Please not that if there's an rsync error in the backup process, the incomplete backup will be deleted to keep data integrety. The script won't try again automatically (until it's executed again by cron).
+- **Limitation**: There will only be one backup per day, as this is how the scripts are designed. Even if you modify the cronjob to run multiple times a day, the existing backup will just be overwritten, but not saved separately.
+	- You can on the other hand use a crontab format that creates backups less often than every day, for example every two days or every week
+- You can run `docker exec sftp-backup backup-now` to manually start a backup

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Make sure that the folder `backup/` exists in the root folder of your SFTP-User 
 |backup_port|Zahl (0-65535)|Ja|Port SFTP server|-
 |backup_user|String|Ja|SFTP username|-
 |backup_bwlimit|number and unit|Optional|Bandwith limit during the backup. Always add a unit, e.g. M = Megabyte|4M
-|backup_manual_frequency|See Crontab |Optional|See https://crontab.guru|10 3 * * *
+|backup_frequency|See Crontab |Optional|See https://crontab.guru|10 3 * * *
 |backup_retention_number|int| Optional|Keeps last X (daily) Backups|7
 |TZ|Continent/City|Optional|Timezone (see [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))|Europe/Berlin
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Make sure that the folder `backup/` exists in the root folder of your SFTP-User 
 ---
 |Variable|Format|Mandatory?|Info|Default value
 |--|--|--|--|--|
-|backup_address|domain.com \| IP|Ja| URL or IP of the SFTP server|-
+|backup_server|domain.com \| IP|Ja| URL or IP of the SFTP server|-
 |backup_port|Zahl (0-65535)|Ja|Port SFTP server|-
 |backup_user|String|Ja|SFTP username|-
 |backup_bwlimit|number and unit|Optional|Bandwith limit during the backup. Always add a unit, e.g. M = Megabyte|4M

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -60,7 +60,7 @@ info "Using bandwith limit: $backup_bwlimit"
 info "Mounting SFTP folder."
 # SFTP:
 set -x
-sshfs -v -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ConnectTimeout=20 $backup_user@$backup_address:/ $sftp_folder
+sshfs -v -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,ConnectTimeout=20 $backup_user@$backup_server:/ $sftp_folder
 set +x
 # Check Mountpoint:
 if mountpoint -q -- "$sftp_folder"

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -171,7 +171,7 @@ else
   ok "No backups need to be deleted. ($found of $backup_retention_number (retention) backups found)."
 fi
 
-info "Size of lokal backup folder: " $(du -sh $dest_folder)
+info "Size of lokal backup folder: $(du -sh $dest_folder)"
 echo
 info "Individual backup folders:"
 du -sh $dest_folder*

--- a/scripts/cron_update.sh
+++ b/scripts/cron_update.sh
@@ -3,12 +3,12 @@
 # Editable Variables:
 backup_cron_freq="10 3 * * *"
 
-if [ -z "$backup_manuelle_frequenz" ]
+if [ -z "$backup_frequency" ]
 then
-  echo "Keine manuelle Cron-Frequenz gesetzt, verwende Standardfrequenz: $backup_cron_freq"
+  echo "No customized cron frequency set, using default frequency: $backup_cron_freq"
 else
-  backup_cron_freq=$backup_manuelle_frequenz
-  echo "Manuelle Cron-Frequenz gesetzt, diese wird verwendet und lautet $backup_cron_freq"
+  backup_cron_freq=$backup_frequency
+  echo "Customized cron frequency set, using frequency: $backup_cron_freq"
 fi
 
 cronedit () {
@@ -18,7 +18,7 @@ cronedit () {
   echo "$backup_cron_freq flock -n /tmp/backup.lock /home/scripts/backup_script.sh |& tee -a /config/logs/backup_script-\$(date +%F).log /var/log/container.log ">>cron.temp
   crontab cron.temp
   rm -f cron.temp
-  echo "Crontab aktualisiert. Starte crond."
+  echo "Crontab successfully updated. Starte crond."
   crond -b
 }
 

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -5,8 +5,8 @@ mkdir /config/logs
 if [ -f "/config/id_rsa.pub" ] && [ -f "/config/id_rsa" ]; then
     echo "Key already exists. Using this key.."
 	rm -rf /home/ssh/*
-	cp /config/id_rsa /home/ssh/ssh_host_rsa_key.pub
-	cp /config/id_rsa.pub /home/ssh/ssh_host_rsa_key
+	cp /config/id_rsa /home/ssh/ssh_host_rsa_key
+	cp /config/id_rsa.pub /home/ssh/ssh_host_rsa_key.pub
 else
     echo "Key wird neu erstellt und kopiert."
 	rm -rf /home/ssh/*

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -26,7 +26,7 @@ else
 fi
 echo "Checking SFTP connection..."
 set -x
-sshfs -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect $backup_nutzername@$backup_adresse:/ /mnt/sftp/
+sshfs -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect $backup_user@$backup_address:/ /mnt/sftp/
 set +x
 sleep 2
 echo "Checking mounted folders..."

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -26,7 +26,7 @@ else
 fi
 echo "Checking SFTP connection..."
 set -x
-sshfs -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect $backup_user@$backup_address:/ /mnt/sftp/
+sshfs -p $backup_port -o BatchMode=yes,IdentityFile=/home/ssh/ssh_host_rsa_key,StrictHostKeyChecking=accept-new,_netdev,reconnect $backup_user@$backup_server:/ /mnt/sftp/
 set +x
 sleep 2
 echo "Checking mounted folders..."

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -8,13 +8,14 @@ fi
 cd /home/scripts
 . ./selfcheck.sh
 . ./cron_update.sh
-echo "------------ Start des laufenden Logs ------------"> /var/log/container.log
+echo "------------ Start container log ------------"> /var/log/container.log
 
 if [ $selfcheck_fail -eq 1 ]
 then
-  echo "Selfcheck fehlgeschlagen! Stoppe Container..."
+  echo "Selfcheck failed! Stopping container..."
   exit 0
 else
-  echo "Selfcheck erfolgreich. Container läuft."
+  echo "Selfcheck passed."
+  echo
   tail -F /var/log/container.log 2> /dev/null
 fi


### PR DESCRIPTION
- Changed project language to English 
- You can now run the `backup-now` command from anywhere in the container to start a backup, or `run docker exec sftp-backup backup-now` on your host system

**WARNING: You can't perform an in-place upgrade!**

Before updating, do the following:
- Stop your existing container
- Rename your existing keyfiles to: `id_rsa` and `id_rsa.pub` instead of `private_key` and `public_key`, they will not be used otherwise
- Change the names of your container variables:
- - backup_adresse to backup_server
- - backup_nutzername to backup_user
- - backup_manuelle_frequenz to backup_frequency
