### PR TITLE
Update to v3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.3
+FROM alpine:3.21.2
 RUN apk add --no-cache rsync openssh-keygen sshfs tzdata coreutils bash findutils jq
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3
+FROM alpine:3.21.3
 RUN apk add --no-cache rsync openssh-keygen sshfs tzdata coreutils bash findutils jq
 RUN cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN mkdir /home/scripts && mkdir /home/ssh && mkdir /config && mkdir /config/logs && mkdir /mnt/sftp
@@ -6,5 +6,5 @@ RUN wget https://github.com/OliveTin/OliveTin/releases/latest/download/OliveTin_
 COPY ./olivetin/config.yaml /etc/OliveTin/
 COPY ./scripts/* /home/scripts/
 RUN chmod +x /home/scripts/*; ln /home/scripts/backup_now.sh /usr/bin/backup-now
-ENV backup_version=3.5.0
+ENV backup_version=3.5.1
 ENTRYPOINT ["/home/scripts/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ There is a simple **Webinterface** for most common actions required to manage th
 |backup_server|domain.com \| IP|Yes| URL or IP of the SFTP server|-
 |backup_port|number (0-65535)|Yes|Port SFTP server|-
 |backup_user|String|Yes|SFTP username|-
-|backup_bwlimit|number and unit|Optional|Bandwith limit during the backup. Always add a unit, e.g. 4M = 4 Megabyte|0 (unlimited)
 |lock_delay|number in seconds|Optional|Retry time when a lockfile is detected|300
 |backup_frequency|See Crontab |Optional|See https://crontab.guru|10 3 * * *
 |backup_retention_number|number| Optional|Keeps last X (daily) Backups|7

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -49,7 +49,6 @@ run_rsync() {
         --stats
         --progress
         --log-file=$logs_folder"rsync-"$backup_start_date".log"
-        --bwlimit=$backup_bwlimit
         $backup_rsync_custom_flags
         $backup_user@$backup_server:$sftp_backup_folder
         $dest_folder$backup_start_date

--- a/scripts/backup_script.sh
+++ b/scripts/backup_script.sh
@@ -159,7 +159,6 @@ sync_pid=$!
 
 echo "---------------   Start backup log $date_today (Using v$backup_version)   -------------------------"
 info "Starting Backup-Script..."
-info "Using bandwith limit: $backup_bwlimit"
 if rsync -q -e "ssh -p $backup_port -i /home/ssh/id_rsa" $backup_user@$backup_server:$sftp_backup_folder ; then
     ok "Connected successfully to SFTP-Server"
 else

--- a/scripts/global_functions.sh
+++ b/scripts/global_functions.sh
@@ -6,7 +6,6 @@ default_lock_delay=300
 default_sftp_backup_folder="/backup/"
 default_sftp_logs_folder="/logs/"
 default_backup_retention_number=7
-default_backup_bwlimit=0
 default_backup_logsync_intervall=60
 
 set_defaults() {
@@ -18,7 +17,7 @@ set_defaults() {
   done
 }
 
-set_defaults backup_retention_number backup_bwlimit backup_logsync_intervall sftp_backup_folder sftp_logs_folder lock_delay
+set_defaults backup_retention_number backup_logsync_intervall sftp_backup_folder sftp_logs_folder lock_delay
 
 time_now () {
   date "+%T"


### PR DESCRIPTION
- Removed default bandwith limit, since sftpgo does not support it natively, you can still set a bwlimit with the "backup_rsync_custom_flags" env variable
- Updated base image to Alpine 3.21.2